### PR TITLE
feat: update SMM creation to use env variables

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,7 +11,7 @@ images:
 configMapGenerator:
   - name: service-mesh-refs
     literals:
-      - CONTROL_PLANE_NAME=minimal
+      - CONTROL_PLANE_NAME=basic
       - MESH_NAMESPACE=istio-system
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,3 +7,11 @@ images:
 - name: controller
   newName: quay.io/bmajsak/odh-project-controller
   newTag: latest
+
+configMapGenerator:
+  - name: service-mesh-refs
+    literals:
+      - CONTROL_PLANE_NAME=minimal
+      - MESH_NAMESPACE=istio-system
+generatorOptions:
+  disableNameSuffixHash: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,8 +55,10 @@ spec:
                 configMapKeyRef:
                   name: service-mesh-refs
                   key: CONTROL_PLANE_NAME
+                  optional: true
             - name: MESH_NAMESPACE
               valueFrom:
                 configMapKeyRef:
                   name: service-mesh-refs
                   key: MESH_NAMESPACE
+                  optional: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,3 +49,14 @@ spec:
             requests:
               cpu: 500m
               memory: 256Mi
+          env:
+            - name: CONTROL_PLANE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: service-mesh-refs
+                  key: CONTROL_PLANE_NAME
+            - name: MESH_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: service-mesh-refs
+                  key: MESH_NAMESPACE

--- a/controllers/enable_mesh.go
+++ b/controllers/enable_mesh.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"os"
 	"reflect"
 	"strconv"
 
@@ -20,23 +19,6 @@ import (
 	"k8s.io/client-go/util/retry"
 	maistrav1 "maistra.io/api/core/v1"
 )
-
-// Helper functions to fetch the relevant environment variables
-func getControlPlaneName() string {
-	controlPlaneName := "basic"
-	if env, defined := os.LookupEnv(ControlPlaneEnv); defined {
-		controlPlaneName = env
-	}
-	return controlPlaneName
-}
-
-func getMeshNamespace() string {
-	meshNamespace := "istio-system"
-	if env, defined := os.LookupEnv(MeshNamespaceEnv); defined {
-		meshNamespace = env
-	}
-	return meshNamespace
-}
 
 // Reconcile will manage the creation, update and deletion of the MeshMember for created the namespace.
 func (r *OpenshiftServiceMeshReconciler) reconcileMeshMember(ctx context.Context, ns *v1.Namespace) error {

--- a/controllers/enable_mesh.go
+++ b/controllers/enable_mesh.go
@@ -21,6 +21,23 @@ import (
 	maistrav1 "maistra.io/api/core/v1"
 )
 
+// Helper functions to fetch the relevant environment variables
+func getControlPlaneName() string {
+	controlPlaneName := "basic"
+	if env, defined := os.LookupEnv(ControlPlaneEnv); defined {
+		controlPlaneName = env
+	}
+	return controlPlaneName
+}
+
+func getMeshNamespace() string {
+	meshNamespace := "istio-system"
+	if env, defined := os.LookupEnv(MeshNamespaceEnv); defined {
+		meshNamespace = env
+	}
+	return meshNamespace
+}
+
 // Reconcile will manage the creation, update and deletion of the MeshMember for created the namespace.
 func (r *OpenshiftServiceMeshReconciler) reconcileMeshMember(ctx context.Context, ns *v1.Namespace) error {
 	log := r.Log.WithValues("feature", "mesh", "namespace", ns.Name)
@@ -71,15 +88,8 @@ func (r *OpenshiftServiceMeshReconciler) reconcileMeshMember(ctx context.Context
 }
 
 func newServiceMeshMember(ns *v1.Namespace) *maistrav1.ServiceMeshMember {
-	controlPlaneName := "basic"
-	if env, defined := os.LookupEnv("CONTROL_PLANE_NAME"); defined {
-		controlPlaneName = env
-	}
-
-	meshNamespace := "istio-system"
-	if env, defined := os.LookupEnv("MESH_NAMESPACE"); defined {
-		meshNamespace = env
-	}
+	controlPlaneName := getControlPlaneName()
+	meshNamespace := getMeshNamespace()
 
 	return &maistrav1.ServiceMeshMember{
 		TypeMeta: metav1.TypeMeta{},
@@ -112,10 +122,7 @@ func serviceMeshIsNotEnabled(meta metav1.ObjectMeta) bool {
 }
 
 func (r *OpenshiftServiceMeshReconciler) findIstioIngress(ctx context.Context) (routev1.RouteList, error) {
-	meshNamespace := "istio-system"
-	if env, defined := os.LookupEnv("MESH_NAMESPACE"); defined {
-		meshNamespace = env
-	}
+	meshNamespace := getMeshNamespace()
 
 	routes := routev1.RouteList{}
 	if err := r.List(ctx, &routes, &client.ListOptions{

--- a/controllers/enable_mesh.go
+++ b/controllers/enable_mesh.go
@@ -71,10 +71,9 @@ func (r *OpenshiftServiceMeshReconciler) reconcileMeshMember(ctx context.Context
 }
 
 func newServiceMeshMember(ns *v1.Namespace) *maistrav1.ServiceMeshMember {
-	// Fetch environment variables
-	controlPlaneName := os.Getenv("CONTROL_PLANE_NAME")
-	if controlPlaneName == "" {
-		controlPlaneName = "basic" // Default value if environment variable is not set
+	controlPlaneName := "basic"
+	if env, defined := os.LookupEnv("CONTROL_PLANE_NAME"); defined {
+		controlPlaneName = env
 	}
 
 	meshNamespace := os.Getenv("MESH_NAMESPACE")

--- a/controllers/enable_mesh.go
+++ b/controllers/enable_mesh.go
@@ -112,10 +112,15 @@ func serviceMeshIsNotEnabled(meta metav1.ObjectMeta) bool {
 }
 
 func (r *OpenshiftServiceMeshReconciler) findIstioIngress(ctx context.Context) (routev1.RouteList, error) {
+	meshNamespace := "istio-system"
+	if env, defined := os.LookupEnv("MESH_NAMESPACE"); defined {
+		meshNamespace = env
+	}
+
 	routes := routev1.RouteList{}
 	if err := r.List(ctx, &routes, &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{"app": "odh-dashboard"}),
-		Namespace:     MeshNamespace,
+		Namespace:     meshNamespace,
 	}); err != nil {
 		r.Log.Error(err, "Unable to find matching gateway")
 		return routev1.RouteList{}, err

--- a/controllers/enable_mesh.go
+++ b/controllers/enable_mesh.go
@@ -76,9 +76,9 @@ func newServiceMeshMember(ns *v1.Namespace) *maistrav1.ServiceMeshMember {
 		controlPlaneName = env
 	}
 
-	meshNamespace := os.Getenv("MESH_NAMESPACE")
-	if meshNamespace == "" {
-		meshNamespace = "istio-system" // Default value if environment variable is not set
+	meshNamespace := "istio-system"
+	if env, defined := os.LookupEnv("MESH_NAMESPACE"); defined {
+		meshNamespace = env
 	}
 
 	return &maistrav1.ServiceMeshMember{
@@ -88,7 +88,6 @@ func newServiceMeshMember(ns *v1.Namespace) *maistrav1.ServiceMeshMember {
 			Namespace: ns.Name,
 		},
 		Spec: maistrav1.ServiceMeshMemberSpec{
-			// TODO should we make it configurable?
 			ControlPlaneRef: maistrav1.ServiceMeshControlPlaneRef{
 				Name:      controlPlaneName,
 				Namespace: meshNamespace,

--- a/controllers/enable_mesh.go
+++ b/controllers/enable_mesh.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"os"
 	"reflect"
 	"strconv"
 
@@ -70,6 +71,17 @@ func (r *OpenshiftServiceMeshReconciler) reconcileMeshMember(ctx context.Context
 }
 
 func newServiceMeshMember(ns *v1.Namespace) *maistrav1.ServiceMeshMember {
+	// Fetch environment variables
+	controlPlaneName := os.Getenv("CONTROL_PLANE_NAME")
+	if controlPlaneName == "" {
+		controlPlaneName = "basic" // Default value if environment variable is not set
+	}
+
+	meshNamespace := os.Getenv("MESH_NAMESPACE")
+	if meshNamespace == "" {
+		meshNamespace = "istio-system" // Default value if environment variable is not set
+	}
+
 	return &maistrav1.ServiceMeshMember{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
@@ -79,8 +91,8 @@ func newServiceMeshMember(ns *v1.Namespace) *maistrav1.ServiceMeshMember {
 		Spec: maistrav1.ServiceMeshMemberSpec{
 			// TODO should we make it configurable?
 			ControlPlaneRef: maistrav1.ServiceMeshControlPlaneRef{
-				Name:      "basic",
-				Namespace: MeshNamespace,
+				Name:      controlPlaneName,
+				Namespace: meshNamespace,
 			},
 		},
 	}

--- a/controllers/mesh_env_lookup.go
+++ b/controllers/mesh_env_lookup.go
@@ -1,0 +1,27 @@
+package controllers
+
+import (
+	"os"
+)
+
+const (
+	MeshNamespaceEnv = "MESH_NAMESPACE"
+	ControlPlaneEnv  = "CONTROL_PLANE_NAME"
+)
+
+// Helper functions to fetch the relevant environment variables
+func getControlPlaneName() string {
+	controlPlaneName := "basic"
+	if env, defined := os.LookupEnv(ControlPlaneEnv); defined {
+		controlPlaneName = env
+	}
+	return controlPlaneName
+}
+
+func getMeshNamespace() string {
+	meshNamespace := "istio-system"
+	if env, defined := os.LookupEnv(MeshNamespaceEnv); defined {
+		meshNamespace = env
+	}
+	return meshNamespace
+}

--- a/controllers/project_mesh_controller.go
+++ b/controllers/project_mesh_controller.go
@@ -22,7 +22,8 @@ const (
 	AnnotationGateway     = "opendatahub.io/service-mesh-gw"
 	LabelMaistraGw        = "maistra.io/gateway-name"
 	LabelMaistraGwNs      = "maistra.io/gateway-namespace"
-	MeshNamespace         = "istio-system"
+	MeshNamespaceEnv      = "MESH_NAMESPACE"
+	ControlPlaneEnv       = "CONTROL_PLANE_NAME"
 )
 
 // OpenshiftServiceMeshReconciler holds the controller configuration.

--- a/controllers/project_mesh_controller.go
+++ b/controllers/project_mesh_controller.go
@@ -22,8 +22,6 @@ const (
 	AnnotationGateway     = "opendatahub.io/service-mesh-gw"
 	LabelMaistraGw        = "maistra.io/gateway-name"
 	LabelMaistraGwNs      = "maistra.io/gateway-namespace"
-	MeshNamespaceEnv      = "MESH_NAMESPACE"
-	ControlPlaneEnv       = "CONTROL_PLANE_NAME"
 )
 
 // OpenshiftServiceMeshReconciler holds the controller configuration.

--- a/controllers/project_mesh_controller_test.go
+++ b/controllers/project_mesh_controller_test.go
@@ -143,8 +143,10 @@ var _ = When("Namespace is created", Label(labels.EvnTest), func() {
 					},
 				},
 			}
-			os.Setenv("CONTROL_PLANE_NAME", "minimal")
-			os.Setenv("MESH_NAMESPACE", "system-of-istio")
+			_ = os.Setenv("CONTROL_PLANE_NAME", "minimal")
+			defer os.Unsetenv("CONTROL_PLANE_NAME")
+			_ = os.Setenv("MESH_NAMESPACE", "system-of-istio")
+			defer os.Unsetenv("MESH_NAMESPACE")
 
 			// when
 			Expect(cli.Create(context.Background(), testNs)).To(Succeed())

--- a/controllers/project_mesh_controller_test.go
+++ b/controllers/project_mesh_controller_test.go
@@ -143,10 +143,10 @@ var _ = When("Namespace is created", Label(labels.EvnTest), func() {
 					},
 				},
 			}
-			_ = os.Setenv("CONTROL_PLANE_NAME", "minimal")
-			defer os.Unsetenv("CONTROL_PLANE_NAME")
-			_ = os.Setenv("MESH_NAMESPACE", "system-of-istio")
-			defer os.Unsetenv("MESH_NAMESPACE")
+			_ = os.Setenv(controllers.ControlPlaneEnv, "minimal")
+			defer os.Unsetenv(controllers.ControlPlaneEnv)
+			_ = os.Setenv(controllers.MeshNamespaceEnv, "system-of-istio")
+			defer os.Unsetenv(controllers.MeshNamespaceEnv)
 
 			// when
 			Expect(cli.Create(context.Background(), testNs)).To(Succeed())

--- a/controllers/project_mesh_controller_test.go
+++ b/controllers/project_mesh_controller_test.go
@@ -165,6 +165,8 @@ var _ = When("Namespace is created", Label(labels.EvnTest), func() {
 				Expect(member.Spec.ControlPlaneRef.Name).To(Equal("minimal"))
 				Expect(member.Spec.ControlPlaneRef.Namespace).To(Equal("system-of-istio"))
 			})
+			os.Setenv("CONTROL_PLANE_NAME", "")
+			os.Setenv("MESH_NAMESPACE", "")
 		})
 	})
 

--- a/controllers/project_mesh_controller_test.go
+++ b/controllers/project_mesh_controller_test.go
@@ -167,8 +167,6 @@ var _ = When("Namespace is created", Label(labels.EvnTest), func() {
 				Expect(member.Spec.ControlPlaneRef.Name).To(Equal("minimal"))
 				Expect(member.Spec.ControlPlaneRef.Namespace).To(Equal("system-of-istio"))
 			})
-			os.Setenv("CONTROL_PLANE_NAME", "")
-			os.Setenv("MESH_NAMESPACE", "")
 		})
 	})
 


### PR DESCRIPTION
Closes #23 

- Modifies SMM creation logic to use environment variables to populate the control plane reference fields (SMCP name and ns).
- Adds tests to ensure that when env vars are not set, defaults are populated and another ensuring that when vars are set, the SMM object is populated with what the env vars contain.
- Changes kustomize files to add configmap (does not change image reference)

Tested in CRC with kustomize using the ConfigMapGenerator to populate env vars and tested without vars set as well to ensure defaults work.