### PR TITLE
chore: exposes audiences through env var

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,6 +65,12 @@ spec:
             - name: AUTHORINO_LABEL
               valueFrom:
                 configMapKeyRef:
-                  name: service-mesh-refs
+                  name: auth-refs
                   key: AUTHORINO_LABEL
+                  optional: true
+            - name: AUTH_AUDIENCE
+              valueFrom:
+                configMapKeyRef:
+                  name: auth-refs
+                  key: AUTH_AUDIENCE
                   optional: true

--- a/controllers/enable_authorino.go
+++ b/controllers/enable_authorino.go
@@ -86,7 +86,7 @@ func (r *OpenshiftServiceMeshReconciler) createAuthConfig(ns *v1.Namespace, host
 
 	authConfig.SetName(ns.Name + "-protection")
 	authConfig.SetNamespace(ns.Name)
-	keyValue, err := getAuthorinoTopic()
+	keyValue, err := getAuthorinoLabel()
 	if err != nil {
 		return nil, err
 	}
@@ -100,6 +100,8 @@ func (r *OpenshiftServiceMeshReconciler) createAuthConfig(ns *v1.Namespace, host
 		Resource:  authorino.StaticOrDynamicValue{Value: "notebooks"},
 		Verb:      authorino.StaticOrDynamicValue{Value: "get"},
 	}
+
+	authConfig.Spec.Identity[0].KubernetesAuth.Audiences = getAuthAudience()
 
 	return authConfig, nil
 }

--- a/controllers/mesh_env_config.go
+++ b/controllers/mesh_env_config.go
@@ -11,6 +11,7 @@ const (
 	MeshNamespaceEnv       = "MESH_NAMESPACE"
 	ControlPlaneEnv        = "CONTROL_PLANE_NAME"
 	AuthorinoLabelSelector = "AUTHORINO_LABEL"
+	AuthAudience           = "AUTH_AUDIENCE"
 )
 
 func getControlPlaneName() string {
@@ -21,13 +22,23 @@ func getMeshNamespace() string {
 	return getEnvOr(MeshNamespaceEnv, "istio-system")
 }
 
-func getAuthorinoTopic() ([]string, error) {
-	topic := getEnvOr(AuthorinoLabelSelector, "authorino/topic=odh")
-	keyValue := strings.Split(topic, "=")
+func getAuthorinoLabel() ([]string, error) {
+	label := getEnvOr(AuthorinoLabelSelector, "authorino/topic=odh")
+	keyValue := strings.Split(label, "=")
 	if len(keyValue) != 2 {
-		return nil, errors.Errorf("Expected authorino topic to be in key=value format, got [%s]", topic)
+		return nil, errors.Errorf("Expected authorino label to be in key=value format, got [%s]", label)
 	}
 	return keyValue, nil
+}
+
+func getAuthAudience() []string {
+	aud := getEnvOr(AuthAudience, "https://kubernetes.default.svc")
+	audiences := strings.Split(aud, ",")
+	for i := range audiences {
+		audiences[i] = strings.TrimSpace(audiences[i])
+	}
+	return audiences
+
 }
 
 func getEnvOr(key, defaultValue string) string {


### PR DESCRIPTION
Underneath it's optionally mounted from the config map but defaults to a previously hardcoded value.

Related to https://issues.redhat.com/browse/OSSM-4356