### PR TITLE
fix(smm): uses namespace name when fetching SMM while reconciling

### DIFF
--- a/controllers/enable_mesh.go
+++ b/controllers/enable_mesh.go
@@ -52,7 +52,7 @@ func (r *OpenshiftServiceMeshReconciler) reconcileMeshMember(ctx context.Context
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			if err := r.Get(ctx, types.NamespacedName{
 				Name:      desiredMeshMember.Name,
-				Namespace: ns.Namespace,
+				Namespace: ns.Name,
 			}, foundMember); err != nil {
 				return err
 			}


### PR DESCRIPTION
Previously it wrongly used `ns.Namespace` which is blank. That was leading to errors.