### PR TITLE
feat(linter): introduces Golang linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: linters
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  go-lint:
+    name: golangci-lint
+    runs-on: ubuntu-20.04
+    env:
+      REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Set up Go env
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          path: go/src/github.com/${{ env.REPOSITORY }}
+      - name: Set $GOPATH
+        run: |
+          echo "GOPATH=${{ github.workspace }}/go" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/go/bin" >> $GITHUB_PATH
+        shell: bash
+      - name: Prepare codebase for linter (generates deps, stubs)
+        run: |
+          cd go/src/github.com/${{ env.REPOSITORY }}
+          make deps generate
+        shell: bash
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.53
+          working-directory: go/src/github.com/${{ env.REPOSITORY }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,112 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 16
+  cyclop:
+    max-complexity: 16
+  dupl:
+    threshold: 128
+  funlen:
+    lines: 128
+    statements: 64
+  goconst:
+    min-len: 4
+    min-occurrences: 3
+  depguard:
+    list-type: blacklist
+    packages:
+      - github.com/sirupsen/logrus
+      - sigs.k8s.io/controller-runtime/pkg/log
+      - sigs.k8s.io/controller-runtime/pkg/log/zap
+      - sigs.k8s.io/controller-runtime/pkg/runtime/log
+  misspell:
+    locale: US
+    ignore-words:
+      - istio
+      - k8s
+  lll:
+    line-length: 180
+  goimports:
+    local-prefixes: github.com/maistra/odh-project-controller
+  gocritic:
+    enabled-tags:
+      - performance
+      - style
+      - experimental
+    disabled-checks:
+      - wrapperFunc
+      - commentFormatting # https://github.com/go-critic/go-critic/issues/755
+      - hugeParam # seems to be premature optimization based on https://github.com/Maistra/istio-workspace/pull/378#discussion_r392208906
+  nestif:
+    min-complexity: 8
+  unused:
+    check-exported: true
+  gocognit:
+    min-complexity: 20
+  wrapcheck:
+    ignoreSigs:
+      - .Errorf(
+      - errors.New(
+      - errors.Unwrap(
+      - .Wrap(
+      - .Wrapf(
+      - .WithMessage(
+      - errors.WrapIfWithDetails
+      - errors.WithDetails(
+      - errors.WrapWithDetails(
+      - errors.WrapIf(
+      - errors.NewWithDetails(
+
+linters:
+  enable-all: true
+  disable:
+    - depguard
+    - exhaustruct
+    - exhaustivestruct
+    - forbidigo
+    - gofmt # We use goimports and when using them both leads to contradicting errors
+    - gofumpt
+    - gomnd
+    - paralleltest
+    - prealloc
+
+run:
+  deadline: 10m
+
+output:
+  format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-rules:
+    - path: test/
+      linters:
+        - goconst
+        - gocyclo
+        - golint
+        - errcheck
+        - dupl
+        - gosec
+        - revive
+        - stylecheck
+        - wrapcheck
+    # Exclude particular linters for tests files.
+    - path: _test\.go
+      linters:
+        - gochecknoglobals
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+        - revive
+        - wrapcheck
+    - path: _suite_test\.go
+      linters:
+        - revive
+        - unused

--- a/controllers/converter.go
+++ b/controllers/converter.go
@@ -4,21 +4,24 @@ import (
 	"bytes"
 
 	"github.com/manifestival/manifestival"
+	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func ConvertToStructuredResource(yamlContent []byte, out interface{}, opts ...manifestival.Option) error {
 	reader := bytes.NewReader(yamlContent)
-	m, err := manifestival.ManifestFrom(manifestival.Reader(reader), opts...)
+
+	manifest, err := manifestival.ManifestFrom(manifestival.Reader(reader), opts...)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed reading manifest")
 	}
 
 	s := scheme.Scheme
 	RegisterSchemes(s)
-	err = s.Convert(&m.Resources()[0], out, nil)
-	if err != nil {
-		return err
+
+	if err := s.Convert(&manifest.Resources()[0], out, nil); err != nil {
+		return errors.Wrap(err, "failed converting manifest")
 	}
+
 	return nil
 }

--- a/controllers/enable_mesh.go
+++ b/controllers/enable_mesh.go
@@ -5,71 +5,79 @@ import (
 	"reflect"
 	"strconv"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	routev1 "github.com/openshift/api/route/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
-
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	maistrav1 "maistra.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Reconcile will manage the creation, update and deletion of the MeshMember for created the namespace.
-func (r *OpenshiftServiceMeshReconciler) reconcileMeshMember(ctx context.Context, ns *v1.Namespace) error {
-	log := r.Log.WithValues("feature", "mesh", "namespace", ns.Name)
+func (r *OpenshiftServiceMeshReconciler) reconcileMeshMember(ctx context.Context, namespace *v1.Namespace) error {
+	log := r.Log.WithValues("feature", "mesh", "namespace", namespace.Name)
 
-	desiredMeshMember := newServiceMeshMember(ns)
+	desiredMeshMember := newServiceMeshMember(namespace)
 	foundMember := &maistrav1.ServiceMeshMember{}
 	justCreated := false
+
 	err := r.Get(ctx, types.NamespacedName{
 		Name:      desiredMeshMember.Name,
-		Namespace: ns.Name,
+		Namespace: namespace.Name,
 	}, foundMember)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			log.Info("Adding namespace to the mesh")
+
 			err = r.Create(ctx, desiredMeshMember)
 			if err != nil && !apierrs.IsAlreadyExists(err) {
 				log.Error(err, "Unable to create ServiceMeshMember")
-				return err
+
+				return errors.Wrap(err, "unable to create ServiceMeshMember")
 			}
+
 			justCreated = true
 		} else {
 			log.Error(err, "Unable to fetch the ServiceMeshMember")
-			return err
+
+			return errors.Wrap(err, "unable to fetch the ServiceMeshMember")
 		}
 	}
 
 	// Reconcile the membership spec if it has been manually modified
 	if !justCreated && !compareMeshMembers(*desiredMeshMember, *foundMember) {
 		log.Info("Reconciling ServiceMeshMember")
+
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			if err := r.Get(ctx, types.NamespacedName{
 				Name:      desiredMeshMember.Name,
-				Namespace: ns.Namespace,
+				Namespace: namespace.Name,
 			}, foundMember); err != nil {
-				return err
+				return errors.Wrapf(err, "failed getting ServieMeshMember %s in namespace %s", desiredMeshMember.Name, namespace.Name)
 			}
+
 			foundMember.Spec = desiredMeshMember.Spec
 			foundMember.ObjectMeta.Labels = desiredMeshMember.ObjectMeta.Labels
-			return r.Update(ctx, foundMember)
+
+			return errors.Wrap(r.Update(ctx, foundMember), "failed updating ServiceMeshMember")
 		})
+
 		if err != nil {
 			log.Error(err, "Unable to reconcile the ServiceMeshMember")
-			return err
+
+			return errors.Wrap(err, "unable to reconcile the ServiceMeshMember")
 		}
 	}
 
 	return nil
 }
 
-func newServiceMeshMember(ns *v1.Namespace) *maistrav1.ServiceMeshMember {
+func newServiceMeshMember(namespace *v1.Namespace) *maistrav1.ServiceMeshMember {
 	controlPlaneName := getControlPlaneName()
 	meshNamespace := getMeshNamespace()
 
@@ -77,7 +85,7 @@ func newServiceMeshMember(ns *v1.Namespace) *maistrav1.ServiceMeshMember {
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default", // The name MUST be default, per the maistra docs
-			Namespace: ns.Name,
+			Namespace: namespace.Name,
 		},
 		Spec: maistrav1.ServiceMeshMemberSpec{
 			ControlPlaneRef: maistrav1.ServiceMeshControlPlaneRef{
@@ -97,6 +105,7 @@ func serviceMeshIsNotEnabled(meta metav1.ObjectMeta) bool {
 	serviceMeshAnnotation := meta.Annotations[AnnotationServiceMesh]
 	if serviceMeshAnnotation != "" {
 		enabled, _ := strconv.ParseBool(serviceMeshAnnotation)
+
 		return !enabled
 	}
 
@@ -112,15 +121,17 @@ func (r *OpenshiftServiceMeshReconciler) findIstioIngress(ctx context.Context) (
 		Namespace:     meshNamespace,
 	}); err != nil {
 		r.Log.Error(err, "Unable to find matching gateway")
-		return routev1.RouteList{}, err
+
+		return routev1.RouteList{}, errors.Wrap(err, "unable to find matching gateway")
 	}
 
 	if len(routes.Items) == 0 {
 		route := &routev1.Route{}
+
 		return routes, apierrs.NewNotFound(schema.GroupResource{
 			Group:    route.GroupVersionKind().Group,
 			Resource: route.ResourceVersion,
-		}, "No routes found")
+		}, "no-route-matching-label")
 	}
 
 	return routes, nil

--- a/controllers/mesh_env_config.go
+++ b/controllers/mesh_env_config.go
@@ -25,20 +25,23 @@ func getMeshNamespace() string {
 func getAuthorinoLabel() ([]string, error) {
 	label := getEnvOr(AuthorinoLabelSelector, "authorino/topic=odh")
 	keyValue := strings.Split(label, "=")
+
 	if len(keyValue) != 2 {
 		return nil, errors.Errorf("Expected authorino label to be in key=value format, got [%s]", label)
 	}
+
 	return keyValue, nil
 }
 
 func getAuthAudience() []string {
 	aud := getEnvOr(AuthAudience, "https://kubernetes.default.svc")
 	audiences := strings.Split(aud, ",")
+
 	for i := range audiences {
 		audiences[i] = strings.TrimSpace(audiences[i])
 	}
-	return audiences
 
+	return audiences
 }
 
 func getEnvOr(key, defaultValue string) string {

--- a/controllers/namespace_updater.go
+++ b/controllers/namespace_updater.go
@@ -4,37 +4,35 @@ import (
 	"context"
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (r *OpenshiftServiceMeshReconciler) addGatewayAnnotations(ctx context.Context, ns *v1.Namespace) error {
-	if ns.ObjectMeta.Annotations[AnnotationPublicGatewayExternalHost] != "" &&
-		ns.ObjectMeta.Annotations[AnnotationPublicGatewayInternalHost] != "" &&
-		ns.ObjectMeta.Annotations[AnnotationPublicGatewayName] != "" {
+func (r *OpenshiftServiceMeshReconciler) addGatewayAnnotations(ctx context.Context, namespace *v1.Namespace) error {
+	if namespace.ObjectMeta.Annotations[AnnotationPublicGatewayExternalHost] != "" &&
+		namespace.ObjectMeta.Annotations[AnnotationPublicGatewayInternalHost] != "" &&
+		namespace.ObjectMeta.Annotations[AnnotationPublicGatewayName] != "" {
 		// If annotation is present we have nothing to do
 		return nil
 	}
 
 	routes, err := r.findIstioIngress(ctx)
 	if err != nil {
-		if !apierrs.IsNotFound(err) {
-			return err
-		}
-		// TODO rethink if we shouldn't just fail here
-		r.Log.Info("Unable to find matching istio ingress gateway. Some things might not work.")
-		return nil
+		r.Log.Error(err, "Unable to find matching istio ingress gateway.")
+
+		return err
 	}
 
-	ns.ObjectMeta.Annotations[AnnotationPublicGatewayExternalHost] = ExtractHostName(routes.Items[0].Spec.Host)
-	ns.ObjectMeta.Annotations[AnnotationPublicGatewayInternalHost] = fmt.Sprintf("%s.%s.svc.cluster.local", routes.Items[0].Spec.To.Name, getMeshNamespace())
+	namespace.ObjectMeta.Annotations[AnnotationPublicGatewayExternalHost] = ExtractHostName(routes.Items[0].Spec.Host)
+	namespace.ObjectMeta.Annotations[AnnotationPublicGatewayInternalHost] = fmt.Sprintf("%s.%s.svc.cluster.local", routes.Items[0].Spec.To.Name, getMeshNamespace())
+
 	gateway := extractGateway(routes.Items[0].ObjectMeta)
 	if gateway != "" {
-		ns.ObjectMeta.Annotations[AnnotationPublicGatewayName] = gateway
+		namespace.ObjectMeta.Annotations[AnnotationPublicGatewayName] = gateway
 	}
-	return r.Client.Update(ctx, ns)
+
+	return errors.Wrap(r.Client.Update(ctx, namespace), "failed updating namespace with annotations")
 }
 
 func extractGateway(meta metav1.ObjectMeta) string {
@@ -42,6 +40,7 @@ func extractGateway(meta metav1.ObjectMeta) string {
 	if gwName == "" {
 		return ""
 	}
+
 	gateway := gwName
 
 	gwNs := meta.Labels[LabelMaistraGatewayNamespace]

--- a/main.go
+++ b/main.go
@@ -2,33 +2,31 @@ package main
 
 import (
 	"flag"
+	"os"
+
 	"github.com/opendatahub-io/odh-project-controller/controllers"
 	"github.com/opendatahub-io/odh-project-controller/version"
-	"os"
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
 	"k8s.io/apimachinery/pkg/runtime"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.) to ensure that exec-entrypoint and run can make use of them.
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
 )
 
+//nolint:gochecknoglobals //reason: used only here
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme               = runtime.NewScheme()
+	setupLog             = ctrl.Log.WithName("setup")
+	metricsAddr          string
+	enableLeaderElection bool
+	probeAddr            string
 )
 
-func init() {
+func init() { //nolint:gochecknoinits //reason this way we ensure schemes are always registered before we start anything
 	controllers.RegisterSchemes(scheme)
 }
 
 func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
-	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -59,6 +57,7 @@ func main() {
 	ctrlLog := ctrl.Log.WithName("controllers").
 		WithName("odh-project")
 	ctrlLog.Info("creating controller instance", "version", version.Version, "commit", version.Commit, "build-time", version.BuildTime)
+
 	if err = (&controllers.OpenshiftServiceMeshReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrlLog,
@@ -72,12 +71,14 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
+
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
 
 	setupLog.Info("Starting manager")
+
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,6 @@
 package version
 
+//nolint:gochecknoglobals //reason these are used for binary version output only
 var (
 	// Version hold a semantic version of the running binary.
 	Version = "v0.0.0"


### PR DESCRIPTION
This way we don't have to spend time on it during code reviews and can focus on features instead. `golangci-lint` is a set of linters which are highly customizable (see `.golangci.yaml` for the details). 

This PR enables it both as a make target (part of default one as well as through `make lint`) and GitHub action (which will comment on the problematic code found in the PRs).

I fixed all the problems so we can start fresh.