### PR TITLE
fix(test): checks if resources are not created by polling

### DIFF
--- a/controllers/project_mesh_controller_test.go
+++ b/controllers/project_mesh_controller_test.go
@@ -2,6 +2,7 @@ package controllers_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -21,7 +22,7 @@ import (
 )
 
 const (
-	timeout  = 1 * time.Minute
+	timeout  = 10 * time.Second
 	interval = 250 * time.Millisecond
 )
 
@@ -117,14 +118,18 @@ var _ = When("Namespace is created", Label(labels.EvnTest), func() {
 			By("ensuring no service mesh member created", func() {
 				members := &maistrav1.ServiceMeshMemberList{}
 
-				Eventually(func() error {
-					return cli.List(context.Background(), members, client.InNamespace(testNs.Name))
+				Consistently(func() bool {
+					if err := cli.List(context.Background(), members, client.InNamespace(testNs.Name)); err != nil {
+						fmt.Printf("failed ensuring no service mesh member created: %+v\n", err)
+
+						return false
+					}
+
+					return len(members.Items) == 0
 				}).
 					WithTimeout(timeout).
 					WithPolling(interval).
-					Should(Succeed())
-
-				Expect(members.Items).Should(BeEmpty())
+					Should(BeTrue())
 			})
 		})
 
@@ -300,14 +305,18 @@ var _ = When("Namespace is created", Label(labels.EvnTest), func() {
 			By("ensuring no authorization config has been created", func() {
 				authConfigs := &authorino.AuthConfigList{}
 
-				Eventually(func() error {
-					return cli.List(context.Background(), authConfigs, client.InNamespace(testNs.Name))
+				Consistently(func() bool {
+					if err := cli.List(context.Background(), authConfigs, client.InNamespace(testNs.Name)); err != nil {
+						fmt.Printf("failed ensuring no auth config created: %+v\n", err)
+
+						return false
+					}
+
+					return len(authConfigs.Items) == 0
 				}).
 					WithTimeout(timeout).
 					WithPolling(interval).
-					Should(Succeed())
-
-				Expect(authConfigs.Items).Should(BeEmpty())
+					Should(BeTrue())
 			})
 		})
 	})


### PR DESCRIPTION
Initially we were using Eventually polling strategy from Ginkgo for checking if no error occured while retriving list of resources (SMM or AuthConfig). If that succeeded we were ensuring that this list is empty. 

This is always initially true, so that approach was making both tests rather useless.

This PR reworks them to ensure that lists are consistently empty instead. Additionally timeout has been reduced so they are not taking ages to execute.
