### PR TITLE
chore: aligns manifests with odh-manifest repo

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,13 +5,5 @@ resources:
 - service.yaml
 images:
 - name: controller
-  newName: quay.io/bmajsak/odh-project-controller
+  newName: quay.io/maistra-dev/odh-project-controller
   newTag: latest
-
-configMapGenerator:
-  - name: service-mesh-refs
-    literals:
-      - CONTROL_PLANE_NAME=basic
-      - MESH_NAMESPACE=istio-system
-generatorOptions:
-  disableNameSuffixHash: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,25 +30,6 @@ spec:
             - name: health
               containerPort: 8081
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: health
-            initialDelaySeconds: 15
-            periodSeconds: 20
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: health
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          resources:
-            limits:
-              cpu: 500m
-              memory: 4Gi
-            requests:
-              cpu: 500m
-              memory: 256Mi
           env:
             - name: CONTROL_PLANE_NAME
               valueFrom:
@@ -74,3 +55,22 @@ spec:
                   name: auth-refs
                   key: AUTH_AUDIENCE
                   optional: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 4Gi
+            requests:
+              cpu: 500m
+              memory: 256Mi


### PR DESCRIPTION
No need for a config map generator as env vars in the deployment are optional and we have a logic in place to handle defaults https://github.com/maistra/odh-project-controller/blob/03963f271f3dfddd16fe70206665bdde7a0235ae/controllers/mesh_env_config.go