### PR TITLE
feat(dependabot): groups k8s deps together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     rebase-strategy: "disabled"
     reviewers:
       - bartoszmajsak
+    groups:
+      k8s-core:
+        dependency-type: production
+        patterns:
+          - "k8s.io/api"
+          - "k8s.io/apimachinery"
+          - "k8s.io/code-generator"        
 
   - package-ecosystem: "docker"
     directory: "/build"


### PR DESCRIPTION
So we can have one PR instead of 3. Makes it easier for testing.