### PR TITLE
fix: improves removed annotation predicate

### DIFF
--- a/controllers/predicates.go
+++ b/controllers/predicates.go
@@ -35,7 +35,10 @@ func MeshAwareNamespaces() predicate.Funcs {
 }
 
 func annotationRemoved(e event.UpdateEvent, annotation string) bool {
-	return e.ObjectOld.GetAnnotations()[annotation] != "" && e.ObjectNew.GetAnnotations()[annotation] == ""
+	_, existsInOld := e.ObjectOld.GetAnnotations()[annotation]
+	_, existsInNew := e.ObjectNew.GetAnnotations()[annotation]
+
+	return existsInOld && !existsInNew
 }
 
 var reservedNamespaceRegex = regexp.MustCompile(`^(openshift|istio-system)$|^(kube|openshift)-.*$`)


### PR DESCRIPTION
Checks if value was set to anything previously and if it is removed now by using second return value (typically called `ok` or `found`) of getting value for a given key in the map.

Do not ask me why I wrote it differently in the first attempt...